### PR TITLE
Use the same groupid as the SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.transbankdevelopers</groupId>
-    <artifactId>transbank-onepay-sdk-java-example</artifactId>
+    <artifactId>transbank-sdk-java-onepay-example</artifactId>
     <version>1.0.1</version>
 
     <packaging>war</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>cl.transbank.onepay</groupId>
+    <groupId>com.github.transbankdevelopers</groupId>
     <artifactId>transbank-onepay-sdk-java-example</artifactId>
     <version>1.0.1</version>
 


### PR DESCRIPTION
We are going to add more java examples to the repository. 

And it's a bit confusing that we don't use the same groupId for all of them. 

We can't change the one on the SDK, so let's change this one.