### PR TITLE
Fix logo URL for checkout

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/shoppingcart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/shoppingcart.jsp
@@ -624,7 +624,7 @@
     function doCheckout() {
         var options = {
             endpoint: './transaction-create.html',
-            commerceLogo: '/onepay-sdk-example/images/icons/logo-01.png',
+            commerceLogo: 'images/icons/logo-01.png',
             callbackUrl: './transaction-commit.html'
         };
 


### PR DESCRIPTION
It had the context root hardcoded. Relative urls are not always a great idea for the logo URL, but it should work for us in our little example. 