### PR TITLE
 Get JS SDK from unpkg, specifying only MAJOR version

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/shoppingcart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/shoppingcart.jsp
@@ -557,7 +557,7 @@
         var t = n.getElementsByTagName("script")[0];
         p = t.parentNode;
         p.insertBefore(s, t);
-    })(false, document, "https://cdn.rawgit.com/TransbankDevelopers/transbank-sdk-js-onepay/v1.5.9/lib/merchant.onepay.min.js",
+    })(false, document, "https://unpkg.com/transbank-onepay-frontend-sdk@1/lib/merchant.onepay.min.js",
         "script",window, function () {
             console.log("Onepay JS library successfully loaded.");
         });


### PR DESCRIPTION
The JS SDK is locked to MAJOR version only, because this example project has tests.

Travis CI is scheduled to run the tests on a daily basis.