### PR TITLE
Permit optional env vars to replace default secrets

### DIFF
--- a/src/main/java/cl/transbank/onepay/example/AppContextListener.java
+++ b/src/main/java/cl/transbank/onepay/example/AppContextListener.java
@@ -1,6 +1,7 @@
 package cl.transbank.onepay.example;
 
 import cl.transbank.onepay.Onepay;
+import org.springframework.util.StringUtils;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
@@ -8,7 +9,8 @@ import javax.servlet.ServletContextListener;
 public class AppContextListener implements ServletContextListener {
     @Override
     public void contextInitialized(ServletContextEvent servletContextEvent) {
-        if (System.getenv("LIVE_API_KEY") != null && System.getenv("LIVE_SHARED_SECRET") != null){
+        if (!StringUtils.isEmpty(System.getenv("LIVE_API_KEY")) &&
+                !StringUtils.isEmpty(System.getenv("LIVE_SHARED_SECRET"))){
             Onepay.setIntegrationType(Onepay.IntegrationType.LIVE);
             Onepay.setApiKey(System.getenv("LIVE_API_KEY"));
             Onepay.setSharedSecret(System.getenv("LIVE_SHARED_SECRET"));

--- a/src/main/java/cl/transbank/onepay/example/AppContextListener.java
+++ b/src/main/java/cl/transbank/onepay/example/AppContextListener.java
@@ -1,0 +1,22 @@
+package cl.transbank.onepay.example;
+
+import cl.transbank.onepay.Onepay;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+public class AppContextListener implements ServletContextListener {
+    @Override
+    public void contextInitialized(ServletContextEvent servletContextEvent) {
+        if (System.getenv("LIVE_API_KEY") != null && System.getenv("LIVE_SHARED_SECRET") != null){
+            Onepay.setIntegrationType(Onepay.IntegrationType.LIVE);
+            Onepay.setApiKey(System.getenv("LIVE_API_KEY"));
+            Onepay.setSharedSecret(System.getenv("LIVE_SHARED_SECRET"));
+        }
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent servletContextEvent) {
+
+    }
+}

--- a/src/main/resources/cart-products.json
+++ b/src/main/resources/cart-products.json
@@ -2,13 +2,13 @@
   {
     "imagePath": "images/item-cart-04.jpg",
     "name": "Fresh Strawberries",
-    "price": 36000,
+    "price": 1,
     "quantity": 2
   },
   {
     "imagePath": "images/item-cart-05.jpg",
     "name": "Lightweight Jacket",
-    "price": 16000,
+    "price": 1,
     "quantity": 1
   }
 ]

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -19,4 +19,7 @@
         <url-pattern></url-pattern>
     </servlet-mapping>
 
+    <listener>
+        <listener-class>cl.transbank.onepay.example.AppContextListener</listener-class>
+    </listener>
 </web-app>


### PR DESCRIPTION
This enables the use of LIVE_API_KEY and LIVE_SHARED_SECRET.

When both these env vars are present they are set to be used and the integration type gets changed to `LIVE`